### PR TITLE
Allow parsing plain tags.

### DIFF
--- a/tags_test.go
+++ b/tags_test.go
@@ -20,12 +20,7 @@ func TestParse(t *testing.T) {
 			tag:  "",
 		},
 		{
-			name:    "tag with one key (invalid)",
-			tag:     "json",
-			invalid: true,
-		},
-		{
-			name: "tag with one key (valid)",
+			name: "tag with one key",
 			tag:  `json:""`,
 			exp: []*Tag{
 				{
@@ -168,6 +163,63 @@ func TestParse(t *testing.T) {
 			name: "tag with trailing space",
 			tag:  `json:"foo" `,
 			exp: []*Tag{
+				{
+					Key:  "json",
+					Name: "foo",
+				},
+			},
+		},
+		{
+			name: "plain tag",
+			tag:  `list`,
+			exp: []*Tag{
+				{
+					Key:   "list",
+					Name:  "",
+					Plain: true,
+				},
+			},
+		},
+		{
+			name: "two plain tags",
+			tag:  `list another`,
+			exp: []*Tag{
+				{
+					Key:   "list",
+					Name:  "",
+					Plain: true,
+				},
+				{
+					Key:   "another",
+					Name:  "",
+					Plain: true,
+				},
+			},
+		},
+		{
+			name: "plain tag after regular tag",
+			tag:  `json:"foo" list`,
+			exp: []*Tag{
+				{
+					Key:  "json",
+					Name: "foo",
+				},
+				{
+					Key:   "list",
+					Name:  "",
+					Plain: true,
+				},
+			},
+		},
+		{
+			name: "regular tag after plain tag",
+			tag:  `list json:"foo"`,
+			exp: []*Tag{
+				{
+					Key:   "list",
+					Name:  "",
+					Plain: true,
+				},
 				{
 					Key:  "json",
 					Name: "foo",


### PR DESCRIPTION
C.f. <https://github.com/TencentCloud/tencentcloud-sdk-go/blob/master/tencentcloud/cvm/v20170312/models.go#L57> and a few other places, I'd like us to not fail on that.

Upstream PR is <https://github.com/fatih/structtag/pull/12> for now.